### PR TITLE
Update __init__.py for LibreOffice >= 6

### DIFF
--- a/oosheet/__init__.py
+++ b/oosheet/__init__.py
@@ -40,10 +40,10 @@ if sys.platform == 'win32':
 import uno, re, zipfile, types, inspect, tempfile, shutil, subprocess
 from datetime import datetime, timedelta
 
-# http://codesnippets.services.openoffice.org/Office/Office.MessageBoxWithTheUNOBasedToolkit.snip
-from com.sun.star.awt import WindowDescriptor
-from com.sun.star.awt.WindowClass import MODALTOP
-from com.sun.star.awt.VclWindowPeerAttribute import OK
+# for alert()
+from com.sun.star.awt import MessageBoxButtons as MSG_BUTTONS
+from com.sun.star.awt.MessageBoxType import MESSAGEBOX
+
 
 class OODoc(object):
     """
@@ -173,22 +173,10 @@ class OODoc(object):
 
     def alert(self, msg, title = u'Alert'):
         """Opens an alert window with a message and title, and requires user to click 'Ok'"""
-        parentWin = self.model.CurrentController.Frame.ContainerWindow
-
-        aDescriptor = WindowDescriptor()
-        aDescriptor.Type = MODALTOP
-        aDescriptor.WindowServiceName = 'messbox'
-        aDescriptor.ParentIndex = -1
-        aDescriptor.Parent = parentWin
-        aDescriptor.WindowAttributes = OK
-
-        tk = parentWin.getToolkit()
-        box = tk.createWindow(aDescriptor)
-
-        box.setMessageText(msg)
-
-        if title:
-            box.setCaptionText(title)
+        ctx = self.get_context()
+        toolkit = ctx.ServiceManager.createInstanceWithContext('com.sun.star.awt.Toolkit', ctx)
+        parentWin = toolkit.getDesktopWindow()
+        box = toolkit.createMessageBox(parentWin, MESSAGEBOX, MSG_BUTTONS.BUTTONS_OK, title, str(msg))
 
         box.execute()
 

--- a/oosheet/__init__.py
+++ b/oosheet/__init__.py
@@ -9,14 +9,16 @@ if sys.platform == 'win32':
     #Some environment variables must be modified
 
     #get the install path from registry
-    import _winreg
+    import winreg
     # try with OpenOffice, LibreOffice on W7
-    for _key in [# OpenOffice 3.3
+    for key in [# OpenOffice 3.3
                  "SOFTWARE\\OpenOffice.org\\UNO\\InstallPath",
                  # LibreOffice 3.4.5 on W7
-                 "SOFTWARE\\Wow6432Node\\LibreOffice\\UNO\\InstallPath"]:
+                 "SOFTWARE\\Wow6432Node\\LibreOffice\\UNO\\InstallPath",
+                 # LibreOffice >= 6
+                 "SOFTWARE\\LibreOffice\\UNO\\InstallPath"]:
         try:
-            value = _winreg.QueryValue(_winreg.HKEY_LOCAL_MACHINE, _key)
+            value = winreg.QueryValue(winreg.HKEY_LOCAL_MACHINE, key)
         except Exception as detail:
             _errMess = "%s" % detail
         else:
@@ -75,7 +77,7 @@ class OODoc(object):
 
     def _detect_macro_environment(self):
         for layer in inspect.stack():
-            if layer[1].startswith('vnd.sun.star.tdoc:'):
+            if layer[1].startswith('vnd.sun.star.tdoc:') or 'pythonscript.py' in layer[1]:
                 return True
         return False
 


### PR DESCRIPTION
to avoid errors in LibreOffice >= 6, use winreg and read some more registry keys

those minor changes allow a seamless run in LibreOffice 6 :-)